### PR TITLE
chore: validate spotify client_id and client_secret before initialize…

### DIFF
--- a/spt/auth.go
+++ b/spt/auth.go
@@ -53,6 +53,12 @@ type payload struct {
 }
 
 func InitClient() error {
+	clientID := os.Getenv("SPOTIFY_ID")
+	clientSecret := os.Getenv("SPOTIFY_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return errors.New("SPOTIFY_ID and/or SPOTIFY_SECRET are missing. Please make sure you have set the SPOTIFY_ID and SPOTIFY_SECRET environment variables")
+	}
+
 	token := &oauth2.Token{}
 
 	// shouldn't be nil if the file doesn't exist.


### PR DESCRIPTION
I just added a small code snippet to check if the user has exported the Spotify Client ID and Client Secret before getting the token to perform OAuth.